### PR TITLE
Pass `-coverpkg=./...` to `go test` to compute coverage across all packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ bench:
 .PHONY: cov
 cov:
 	mkdir -p coverage && \
-	go test ./... -coverprofile=./coverage/coverage.out && \
+	go test ./... -coverpkg=./... -coverprofile=./coverage/coverage.out && \
 	gcov2lcov -infile=./coverage/coverage.out -outfile=./coverage/lcov.info
 
 .PHONY: generate

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # ProtoBuf Release Notes
 
-## 0.0.8-dev - 2024-07-23
+## 0.0.8-dev - 2024-07-31
+
+### Continuous Integration
+
+- Pass `-coverpkg=./...` to `go test` to compute coverage across all packages
+  (PR #61 by @chicco785)
 
 ### Documentation
 


### PR DESCRIPTION
## Description

Pass `-coverpkg=./...` to `go test` to compute coverage across all packages

## Changes Made

Pass `-coverpkg=./...` to `go test` to compute coverage across all packages

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [x] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
