### PR TITLE
Add `samplingPeriod` property

### DIFF
--- a/.github/config/md-link-config.json
+++ b/.github/config/md-link-config.json
@@ -5,6 +5,9 @@
         },
         {
             "pattern": "^http://pkg.go.dev/"
+        },
+        {
+            "pattern": "^https://www.typhoon-hil.com/"
         }
     ]
 }

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -98,5 +98,6 @@ issues:
         - goconst
         - init
         - gochecknoinits
+        - dupl
 run:
   timeout: 5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,10 +18,10 @@ linters-settings:
       - whyNoLint
       - unnamedResult
   gofmt:
-      simplify: false
-  rewrite-rules:
-    - pattern: 'interface{}'
-      replacement: 'any'
+    simplify: false
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
   lll:
     line-length: 140
   misspell:
@@ -29,7 +29,6 @@ linters-settings:
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
   revive:
     rules:
       - name: unexported-return
@@ -48,7 +47,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
+    - copyloopvar
     - gochecknoinits
     - goconst
     - gocritic
@@ -92,5 +91,12 @@ linters:
   # - funlen
   # - gomnd
 
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - goconst
+        - init
+        - gochecknoinits
 run:
-  deadline: 5m
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 
 .PHONY: bench
 bench:
-	go test ./... -benchmem -p 1 -run='^$$' -bench='^Benchmark_'
+	go test ./... -benchmem -p 1 -run='^$$' -bench=.
 
 .PHONY: cov
 cov:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 
 .PHONY: bench
 bench:
-	go test ./... -bench=. -run=^$
+        go test ./... -benchmem -p 1 -run='^$$' -bench='^Benchmark_'
 
 .PHONY: cov
 cov:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 
 .PHONY: bench
 bench:
-        go test ./... -benchmem -p 1 -run='^$$' -bench='^Benchmark_'
+	go test ./... -benchmem -p 1 -run='^$$' -bench='^Benchmark_'
 
 .PHONY: cov
 cov:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 # ProtoBuf Release Notes
 
-## 0.0.8-dev - 2024-07-31
+## 0.0.8-dev - 2024-12-17
+
+### Features
+
+- Add `samplingPeriod` property (PR #73 by @chicco785)
 
 ### Continuous Integration
 

--- a/docs/data.proto.md
+++ b/docs/data.proto.md
@@ -207,7 +207,10 @@ Headers used in rabbitMQ (only if not sent as part of `DataSet`):
 * `type` (string): always `Data`
 * `producerId` (string): the id of the producer (e.g. a PMU) linked to the dataset.
 * `timestampId` (int64): related measurement Unix msec timestamp (if any)
-* `aligned` (bool, default true): whether the DataSet has to be time-aligned or not.
+* `aligned` (bool, default true): whether the DataSet has to be time-aligned or
+  not.
+* `samplingPeriod` (string): optional, used to identify timestamps that match
+  `second` or `minute`.
 
 
 
@@ -231,7 +234,8 @@ Headers used in rabbitMQ:
 * `producerId` (string): the id of the producer (e.g. a PMU) linked to the dataset.
 * `timestampId` (int64): related measurement Unix msec timestamp (if any)
 * `aligned` (bool, default true): whether the DataSet has to be time-aligned or not.
-
+* `samplingPeriod` (string): optional, used to identify timestamps that match
+  `second` or `minute`.
 
 
 | Field        | Ordinal | Type           | Label | Description                                                 |

--- a/examples/go/measurements/main.go
+++ b/examples/go/measurements/main.go
@@ -144,6 +144,8 @@ func main() {
 			math.Round(float64(time.Now().UnixMilli())/20) * 20,
 		)
 		messageProperties["producerId"] = data.GetProducerId()
+		messageProperties["aligned"] = false
+		messageProperties["samplingPeriod"] = "msec"
 		message.ApplicationProperties = messageProperties
 		err := producer.Send(message)
 		CheckErr(err)

--- a/examples/go/measurements/main.go
+++ b/examples/go/measurements/main.go
@@ -145,7 +145,7 @@ func main() {
 		)
 		messageProperties["producerId"] = data.GetProducerId()
 		messageProperties["aligned"] = false
-		messageProperties["samplingPeriod"] = "msec"
+		messageProperties["samplingPeriod"] = "second"
 		message.ApplicationProperties = messageProperties
 		err := producer.Send(message)
 		CheckErr(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zaphiro-technologies/protobuf
 
-go 1.21
+go 1.23
 
 require (
 	github.com/google/uuid v1.6.0
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/ccoveille/go-safecast v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ccoveille/go-safecast v1.2.0 h1:H4X7aosepsU1Mfk+098CTdKpsDH0cfYJ2RmwXFjgvfc=
+github.com/ccoveille/go-safecast v1.2.0/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=

--- a/go/grid/v1/event_test.go
+++ b/go/grid/v1/event_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ccoveille/go-safecast"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -27,7 +28,7 @@ import (
 
 func generateEvent(
 	eventId string,
-	eventSourceType int,
+	eventSourceType int32,
 	eventSource string,
 	occurredAt int64,
 	message string,
@@ -44,7 +45,7 @@ func generateEvent(
 }
 
 func TestEvent(t *testing.T) {
-	for k := 0; k < 4; k++ {
+	for k := int32(0); k < 4; k++ {
 		test := generateEvent(
 			uuid.NewString(),
 			k,
@@ -66,9 +67,13 @@ func TestEvent(t *testing.T) {
 }
 
 func BenchmarkEventSerialization(b *testing.B) {
+	randEventSourceType, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	test := generateEvent(
 		uuid.NewString(),
-		rand.Intn(4),
+		randEventSourceType,
 		uuid.NewString(),
 		time.Now().UnixNano(),
 		"my message benchmark event",
@@ -99,7 +104,7 @@ func generateGridEvent(
 }
 
 func TestGridEvent(t *testing.T) {
-	for k := 0; k < 5; k++ {
+	for k := int32(0); k < 5; k++ {
 		event := generateEvent(
 			uuid.NewString(),
 			k,
@@ -127,9 +132,13 @@ func TestGridEvent(t *testing.T) {
 }
 
 func BenchmarkGridEventSerialization(b *testing.B) {
+	randEventSourceType, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	event := generateEvent(
 		uuid.NewString(),
-		rand.Intn(4),
+		randEventSourceType,
 		uuid.NewString(),
 		time.Now().UnixNano(),
 		"my message benchmark grid event",

--- a/go/grid/v1/fault_test.go
+++ b/go/grid/v1/fault_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ccoveille/go-safecast"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -27,7 +28,7 @@ import (
 
 func generateFault(
 	faultId string,
-	faultKind, phaseCode int,
+	faultKind, phaseCode int32,
 	updatedAt int64,
 	faultyEquipmentId string,
 ) *Fault {
@@ -41,11 +42,15 @@ func generateFault(
 }
 
 func TestFault(t *testing.T) {
-	for k := 0; k < 5; k++ {
+	for k := int32(0); k < 5; k++ {
+		randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+		if err != nil {
+			t.Fatalf("Failed to convert int to int32: %v", err)
+		}
 		test := generateFault(
 			uuid.NewString(),
 			k,
-			rand.Intn(26),
+			randPhaseCode,
 			time.Now().UnixNano(),
 			uuid.NewString(),
 		)
@@ -62,10 +67,18 @@ func TestFault(t *testing.T) {
 }
 
 func BenchmarkFaultSerialization(b *testing.B) {
+	randFaultKind, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
+	randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	test := generateFault(
 		uuid.NewString(),
-		rand.Intn(4),
-		rand.Intn(26),
+		randFaultKind,
+		randPhaseCode,
 		time.Now().UnixNano(),
 		uuid.NewString(),
 	)
@@ -87,8 +100,12 @@ func generateLineFault(
 }
 
 func TestLineFault(t *testing.T) {
-	for k := 0; k < 5; k++ {
-		fault := generateFault(uuid.NewString(), k, rand.Intn(26), time.Now().UnixNano(), "line1")
+	for k := int32(0); k < 5; k++ {
+		randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+		if err != nil {
+			t.Fatalf("Failed to convert int to int32: %v", err)
+		}
+		fault := generateFault(uuid.NewString(), k, randPhaseCode, time.Now().UnixNano(), "line1")
 		test := generateLineFault(fault, rand.Float32())
 		buf, err := proto.Marshal(test)
 		assert.NoError(t, err)
@@ -100,10 +117,18 @@ func TestLineFault(t *testing.T) {
 }
 
 func BenchmarkLineFaultSerialization(b *testing.B) {
+	randFaultKind, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
+	randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	fault := generateFault(
 		uuid.NewString(),
-		rand.Intn(4),
-		rand.Intn(26),
+		randFaultKind,
+		randPhaseCode,
 		time.Now().UnixNano(),
 		"line1",
 	)
@@ -126,11 +151,15 @@ func generateEquipmentFault(
 }
 
 func TestEquipmentFault(t *testing.T) {
-	for k := 0; k < 5; k++ {
+	for k := int32(0); k < 5; k++ {
+		randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+		if err != nil {
+			t.Fatalf("Failed to convert int to int32: %v", err)
+		}
 		fault := generateFault(
 			uuid.NewString(),
 			k,
-			rand.Intn(26),
+			randPhaseCode,
 			time.Now().UnixNano(),
 			"equipment1",
 		)
@@ -145,10 +174,18 @@ func TestEquipmentFault(t *testing.T) {
 }
 
 func BenchmarkEquipmentFaultSerialization(b *testing.B) {
+	randFaultKind, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
+	randPhaseCode, err := safecast.ToInt32(rand.Intn(26))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	fault := generateFault(
 		uuid.NewString(),
-		rand.Intn(4),
-		rand.Intn(26),
+		randFaultKind,
+		randPhaseCode,
 		time.Now().UnixNano(),
 		"equipment1",
 	)

--- a/go/platform/v1/task_test.go
+++ b/go/platform/v1/task_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ccoveille/go-safecast"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -32,7 +33,7 @@ func generateTask(taskType TaskType, createdAt int64) *Task {
 }
 
 func TestTask(t *testing.T) {
-	for k := 0; k < 5; k++ {
+	for k := int32(0); k < 5; k++ {
 		test := generateTask(TaskType(k), time.Now().UnixNano())
 		buf, err := proto.Marshal(test)
 		assert.NoError(t, err)
@@ -58,7 +59,7 @@ func generateNotification(
 }
 
 func TestNotification(t *testing.T) {
-	for k := 0; k < 5; k++ {
+	for k := int32(0); k < 5; k++ {
 		test := generateNotification(
 			NotificationType(k),
 			time.Now().UnixNano(),
@@ -94,8 +95,12 @@ func TestTriggerNotification(t *testing.T) {
 }
 
 func BenchmarkNotificationSerialization(b *testing.B) {
+	randInt32, err := safecast.ToInt32(rand.Intn(4))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
 	test := generateNotification(
-		NotificationType(rand.Intn(4)),
+		NotificationType(randInt32),
 		time.Now().UnixNano(),
 		"1",
 	)
@@ -107,7 +112,11 @@ func BenchmarkNotificationSerialization(b *testing.B) {
 }
 
 func BenchmarkTaskSerialization(b *testing.B) {
-	test := generateTask(TaskType(rand.Intn(5)), time.Now().UnixNano())
+	randInt32, err := safecast.ToInt32(rand.Intn(5))
+	if err != nil {
+		b.Fatalf("Failed to convert int to int32: %v", err)
+	}
+	test := generateTask(TaskType(randInt32), time.Now().UnixNano())
 	for i := 0; i < b.N; i++ {
 		buf, _ := proto.Marshal(test)
 		conf := &Task{}

--- a/zaphiro/grid/v1/data.proto
+++ b/zaphiro/grid/v1/data.proto
@@ -88,6 +88,8 @@ Headers used in rabbitMQ (only if not sent as part of `DataSet`):
 * `producerId` (string): the id of the producer (e.g. a PMU) linked to the dataset.
 * `timestampId` (int64): related measurement Unix msec timestamp (if any)
 * `aligned` (bool, default true): whether the DataSet has to be time-aligned or not.
+* `samplingPeriod` (string): optional, used to identify timestamps that match
+  `second` or `minute`.
 */
 
 message Data {
@@ -103,6 +105,8 @@ Headers used in rabbitMQ:
 * `producerId` (string): the id of the producer (e.g. a PMU) linked to the dataset.
 * `timestampId` (int64): related measurement Unix msec timestamp (if any)
 * `aligned` (bool, default true): whether the DataSet has to be time-aligned or not.
+* `samplingPeriod` (string): optional, used to identify timestamps that match
+  `second` or `minute`.
 */
 
 message DataSet {


### PR DESCRIPTION
## Description

This PR document the `samplingPeriod` property for `DataSet` to be used for filtering messages based on their periodicity: `second` or `minute`.

## Changes Made

* Add `samplingPeriod` property
* Fix linting issues

## Related Issues

Related to https://github.com/zaphiro-technologies/c37-118-server/issues/226

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [x] I have added appropriate documentation or updated existing documentation.
