### PR TITLE
stat protobuffer: add latency field

### DIFF
--- a/zaphiro/c37118/v1/stat.proto
+++ b/zaphiro/c37118/v1/stat.proto
@@ -39,4 +39,5 @@ message Stat {
 	uint32 timeQuality    = 8; // Time quality uint8
 	uint32 unlockedTime   = 9; // Unlocked time uint8
 	uint32 triggerReason  = 10; // Trigger reason uint8
+	int64 latency        = 11; // Latency in msec
 }


### PR DESCRIPTION
## Description

This PR adds latency field to stat protobuffer.

## Changes Made

* stat protobuffer: add latency field

## Related Issues

Fixes #108 

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [x] I have added appropriate documentation or updated existing documentation.
